### PR TITLE
🧹 [Code Health] Remove unused `json` import in RedisManager

### DIFF
--- a/searchboost_service/searchboost_src/redis_manager.py
+++ b/searchboost_service/searchboost_src/redis_manager.py
@@ -22,7 +22,6 @@
 
 
 import redis.asyncio as redis
-import json
 
 class RedisManager:
     def __init__(self, config, logger):


### PR DESCRIPTION
🎯 **What:** Removed the unused `json` import from `searchboost_service/searchboost_src/redis_manager.py`.
💡 **Why:** The `json` module was imported but never used in the file, so removing it improves code readability and maintainability.
✅ **Verification:** Verified by checking file contents and running the unit test suite (`pytest searchboost_tests/unit_tests/test.py`), which still passes. 
✨ **Result:** A slightly cleaner and more maintainable `redis_manager.py` file with no dead code.

---
*PR created automatically by Jules for task [7292053356228957190](https://jules.google.com/task/7292053356228957190) started by @Somnerd*