### PR TITLE
🧹 Remove unused RedisSettings import from worker.py

### DIFF
--- a/searchboost_service/searchboost_src/worker.py
+++ b/searchboost_service/searchboost_src/worker.py
@@ -22,7 +22,6 @@
 
 
 import asyncio, logging
-from arq.connections import RedisSettings
 from searchboost_src.configurator import get_configurator
 from searchboost_src.service import SearchBoostService
 from searchboost_src.logger import setup_logger


### PR DESCRIPTION
🎯 **What:** Removed an unused import (`RedisSettings` from `arq.connections`) in `searchboost_service/searchboost_src/worker.py`.
💡 **Why:** Dead code clutters the codebase. Removing unused imports improves maintainability, readability, and reduces potential confusion for developers reading the file.
✅ **Verification:** Verified with `grep` that `RedisSettings` was not used anywhere else in the file. Ran the unit and functional tests with `pytest` and compiled the file to ensure no syntax errors or functional regressions were introduced.
✨ **Result:** The codebase is slightly cleaner and has one fewer unused dependency in `worker.py` without affecting any functionality.

---
*PR created automatically by Jules for task [1461411013363004501](https://jules.google.com/task/1461411013363004501) started by @Somnerd*