### PR TITLE
🧹 Fix unreachable logging statement in service.py

### DIFF
--- a/searchboost_service/searchboost_src/service.py
+++ b/searchboost_service/searchboost_src/service.py
@@ -116,9 +116,8 @@ class SearchBoostService:
 
             final_response = await self.ai_handler.query_LLM(self.chatdetails)
             await self.cache.cache_response(self.args.query, final_response)
-            return final_response
-
             self.logger.info(f"SearchBoostService : Final Response :\n---\n{final_response}")
+            return final_response
         except Exception as e:
             self.logger.error(f"SearchBoostService : CRITICAL Runtime Error: {e}")
 


### PR DESCRIPTION
🎯 **What:** Swapped `return final_response` and `self.logger.info(...)` in `searchboost_service/searchboost_src/service.py`.
💡 **Why:** The logger statement was placed immediately after a `return`, causing it to be unreachable dead code. Moving the logger statement before the return improves readability and makes sure the log actually executes.
✅ **Verification:** Ran pytest tests in `searchboost_tests` and syntax check `python -m py_compile` to ensure the syntax and logic were intact. Code review also returned #Correct#.
✨ **Result:** The system correctly logs the final response without changing functional behavior.

---
*PR created automatically by Jules for task [1533268322811529380](https://jules.google.com/task/1533268322811529380) started by @Somnerd*