### PR TITLE
🧹 Code Health Improvement: Remove Unused Import 'Job'

### DIFF
--- a/searchboost_service/searchboost_src/fallback_handler.py
+++ b/searchboost_service/searchboost_src/fallback_handler.py
@@ -5,7 +5,7 @@
 import asyncio
 import time
 from arq import create_pool
-from arq.jobs import Job, JobStatus
+from arq.jobs import JobStatus
 
 async def perform_direct_search(logger, bundle, args, timeout=120):
     """


### PR DESCRIPTION
🎯 **What:** Removed the unused `Job` import from `searchboost_service/searchboost_src/fallback_handler.py`.
💡 **Why:** The `Job` class is not referenced as a type hint or instantiated in this file, making it safe to remove. This improves code readability and maintainability by removing dead code.
✅ **Verification:** Verified the code health issue is resolved by checking the file, and ensured no functionality is broken by running the unit test suite (`pytest searchboost_tests/unit_tests/test.py`).
✨ **Result:** A cleaner import statement without unused symbols.

---
*PR created automatically by Jules for task [6890011367227997943](https://jules.google.com/task/6890011367227997943) started by @Somnerd*