### PR TITLE
🧹 Remove unused import asyncio in api_client.py

### DIFF
--- a/searchboost_service/searchboost_src/api_client.py
+++ b/searchboost_service/searchboost_src/api_client.py
@@ -20,7 +20,6 @@
 # For licensing outside the scope of AGPLv3, contact: nikolasalexandrakis.work@gmail.com
 # ---------------------------------------------------------------------
 
-import asyncio
 import openai
 from openai import AsyncOpenAI
 from searchboost_src.chat_class import ChatDetails


### PR DESCRIPTION
🎯 **What:** Removed unused `import asyncio` from `searchboost_service/searchboost_src/api_client.py`.
💡 **Why:** Static analysis shows 'asyncio' is not referenced in this module, only AsyncOpenAI is used. It can be safely removed to improve the maintainability and readability of the codebase.
✅ **Verification:** Verified the code health issue is resolved by checking that `import asyncio` is no longer in the file. Ran the test suite to ensure no functionality is broken.
✨ **Result:** Improved codebase cleanliness and maintainability by removing unused code.

---
*PR created automatically by Jules for task [13855294448001856853](https://jules.google.com/task/13855294448001856853) started by @Somnerd*