### PR TITLE
🔒 Fix hardcoded default passwords in Configurator

### DIFF
--- a/searchboost_service/searchboost_src/configurator.py
+++ b/searchboost_service/searchboost_src/configurator.py
@@ -60,7 +60,7 @@ class SearchSettings(BaseModel):
 class RedisSettings(BaseModel):
     host: str = Field(default="sb_redis", description="Redis server host")
     port: int = Field(default=6379, description="Redis server port")
-    password: str = Field(default="searchboost_pass", description="Redis password")
+    password: str = Field(default="", description="Redis password")
     # db: int = Field(default=0, description="Redis database index")
     # decode_responses: bool = Field(default=True)
 
@@ -73,7 +73,7 @@ class PostgreSQLSettings(BaseModel):
     host: str = Field(default="sb_db", description="PostgreSQL server host")
     port: int = Field(default=5432, description="PostgreSQL server port")
     user: str = Field(default="searchboost", description="PostgreSQL username")
-    password: str = Field(default="searchboost_pass", description="PostgreSQL password")
+    password: str = Field(default="", description="PostgreSQL password")
     database: str = Field(default="searchboost_db", description="PostgreSQL database name")
 
     @property


### PR DESCRIPTION
🎯 **What:** Removed hardcoded passwords in the Pydantic configurations for Redis and PostgreSQL inside the SearchBoost configurator.
⚠️ **Risk:** Hardcoded default credentials visible in source control can easily be deployed to production by unobservant users, leading to unauthorized access to the application's underlying database infrastructure.
🛡️ **Solution:** Replaced the hardcoded strings with empty strings. The application will now rely on environment variables and secure configuration files to populate credentials, significantly reducing the risk of accidental exposure.

---
*PR created automatically by Jules for task [17249028898063354353](https://jules.google.com/task/17249028898063354353) started by @Somnerd*