### PR TITLE
🔒 Remove hardcoded passwords from configuration

### DIFF
--- a/configs/db.json
+++ b/configs/db.json
@@ -2,6 +2,5 @@
     "host": "sb_db",
     "port": 5432,
     "user": "searchboost",
-    "password": "searchboost_pass",
     "database": "searchboost_db"
 }

--- a/configs/redis.json
+++ b/configs/redis.json
@@ -1,7 +1,6 @@
 {
     "host": "sb_redis",
     "port": 6379,
-    "password": "searchboost_pass",
     "db": 0,
     "decode_responses": true,
     "conn_timeout": 5,

--- a/configs/service_settings.json
+++ b/configs/service_settings.json
@@ -12,7 +12,6 @@
     "redis" : {
         "host": "sb_redis",
         "port": 6379,
-        "password": "searchboost_pass",
         "db": 0,
         "decode_responses": true,
         "conn_timeout": 5,
@@ -29,7 +28,6 @@
         "host": "sb_db",
         "port": 5432,
         "user": "searchboost",
-        "password": "searchboost_pass",
         "database": "searchboost_db"
     },
     "cloud_ai" : {

--- a/configs/warden.ini
+++ b/configs/warden.ini
@@ -4,7 +4,6 @@ relay_port = 14141
 [redis]
 host = sb_redis
 port = 6379
-password = searchboost_pass
 
 [observer]
 container_name = sb_worker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - ./logs:/logs
     environment:
       - WARDEN_CONFIG_PATH=/configs/warden.ini
+      - WARDEN__REDIS__PASSWORD=${REDIS_PASSWORD}
       - RUST_LOG=info
     depends_on:
       - redis
@@ -28,7 +29,8 @@ services:
       - SEARCHBOOST_AI_HOST=sb_ollama
       - SEARCHBOOST_SEARCH_HOST=sb_searxng
       - PYTHONBUFFERED=1
-      - SEARCHBOOST_REDIS_PASSWORD=${REDIS_PASSWORD:-searchboost_pass}
+      - SEARCHBOOST_REDIS_PASSWORD=${REDIS_PASSWORD}
+      - SEARCHBOOST_DB_PASSWORD=${DB_PASSWORD}
       - PYTHONPATH=/app
     command : arq searchboost_src.worker.WorkerSettings
     volumes:
@@ -43,9 +45,11 @@ services:
   redis:
     image: redis:7.4-alpine
     container_name: sb_redis
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
     ports:
       - "${REDIS_PORT:-6379}:6379"
-    command: redis-server --requirepass ${REDIS_PASSWORD:-searchboost_pass} --appendonly yes
+    command: sh -c 'if [ -n "$$REDIS_PASSWORD" ]; then redis-server --requirepass "$$REDIS_PASSWORD" --appendonly yes; else redis-server --appendonly yes; fi'
     volumes:
       - redis_data:/data
     restart: always
@@ -79,7 +83,7 @@ services:
       restart: always
       environment:
         - POSTGRES_USER=${DB_USER:-searchboost}
-        - POSTGRES_PASSWORD=${DB_PASSWORD:-searchboost_pass}
+        - POSTGRES_PASSWORD=${DB_PASSWORD}
         - POSTGRES_DB=${DB_NAME:-searchboost_db}
       ports:
         - "${POSTGRES_PORT:-5432}:5432"

--- a/searchboost_service/searchboost_src/configurator.py
+++ b/searchboost_service/searchboost_src/configurator.py
@@ -60,7 +60,7 @@ class SearchSettings(BaseModel):
 class RedisSettings(BaseModel):
     host: str = Field(default="sb_redis", description="Redis server host")
     port: int = Field(default=6379, description="Redis server port")
-    password: str = Field(default="searchboost_pass", description="Redis password")
+    password: Optional[str] = Field(default=None, description="Redis password")
     # db: int = Field(default=0, description="Redis database index")
     # decode_responses: bool = Field(default=True)
 
@@ -73,7 +73,7 @@ class PostgreSQLSettings(BaseModel):
     host: str = Field(default="sb_db", description="PostgreSQL server host")
     port: int = Field(default=5432, description="PostgreSQL server port")
     user: str = Field(default="searchboost", description="PostgreSQL username")
-    password: str = Field(default="searchboost_pass", description="PostgreSQL password")
+    password: Optional[str] = Field(default=None, description="PostgreSQL password")
     database: str = Field(default="searchboost_db", description="PostgreSQL database name")
 
     @property


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Hardcoded weak default passwords (`searchboost_pass`) were defined in several configuration files (`configs/redis.json`, `configs/db.json`, `configs/warden.ini`, `configs/service_settings.json`), and used as fallback defaults in Pydantic models and Docker Compose files.

⚠️ **Risk:** The potential impact if left unfixed
Any unauthorized entity with read access to the repository or config files would be able to discover the default credentials, which could lead to unauthorized database or Redis access, compromising system security and data integrity.

🛡️ **Solution:** How the fix addresses the vulnerability
- Removed hardcoded default passwords from all `.json` and `.ini` config files.
- Updated Pydantic defaults in `searchboost_service/searchboost_src/configurator.py` to be `Optional[str] = Field(default=None)` instead of hardcoded strings.
- Refactored `docker-compose.yml` to rely entirely on environment variables (e.g. `${REDIS_PASSWORD}`) without providing fallback strings.
- Added conditionals in the `docker-compose.yml` `redis` entrypoint to only use `--requirepass` if a password variable is supplied, preventing startup failures when a password is not needed in dev, while forcing Postgres configuration to explicitly fail when variables are omitted.
- Updated `warden.ini` environment variable mapping in `docker-compose.yml` to inject the Redis password.

---
*PR created automatically by Jules for task [3367325848154751882](https://jules.google.com/task/3367325848154751882) started by @Somnerd*